### PR TITLE
Improve handling of bad arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+### Added
+- `UserAgentBag` constructor creates an empty bag when passed `undefined` or `null`
+- `UserAgentBag` constructor throws when other invalid types are passed
+
+### Fixed
+- Parsing is skipped if the length is too large
+
 ## 0.1.0 - 2019-05-14
 ### Added
 - `UserAgentBag` class with `entries`, `get`, `getAll`, `has`, and `toString`

--- a/UserAgentBag.js.flow
+++ b/UserAgentBag.js.flow
@@ -14,7 +14,7 @@ type UserAgentBagNode = (
 );
 
 declare class UserAgentBag {
-  constructor(arg: string | Entries): UserAgentBag;
+  constructor(arg: string | Entries | null | void): UserAgentBag;
 
   get(product: string): string | null | void;
   getAll(product: string): Array<string | null | void>;

--- a/test/UserAgentBag.test.js
+++ b/test/UserAgentBag.test.js
@@ -45,7 +45,7 @@ test('can convert entries to a bag', t => {
   t.is(bag.toString(), 'Foo/bar Baz Foo/two')
 })
 
-test('fails if the string is malformed', t => {
+test('returns an empty bag if the string is malformed', t => {
   const testCases = [
     '',
     'NoVersion/',
@@ -61,5 +61,27 @@ test('fails if the string is malformed', t => {
   for (const testCase of testCases) {
     const bag = new UserAgentBag(testCase)
     t.deepEqual([...bag.entries()], [])
+  }
+})
+
+test('returns an empty bag if null or undefined are passed', t => {
+  const nullBag = new UserAgentBag(null)
+  t.deepEqual([...nullBag.entries()], [])
+
+  const undefinedBag = new UserAgentBag(undefined)
+  t.deepEqual([...undefinedBag.entries()], [])
+})
+
+test('throws if bogus types are passed', t => {
+  const testCases = [
+    0,
+    123,
+    true,
+    false,
+    { toString: () => 'User/agent' }
+  ]
+
+  for (const testCase of testCases) {
+    t.throws(() => new UserAgentBag(/*:: ( */ testCase /*:: : any) */))
   }
 })


### PR DESCRIPTION
Three changes:

- Constructor now creates an empty bag when passed `undefined` or `null`
- Constructor now throws when other invalid types are passed. This shouldn't be possible if you're using Flow.
- Parsing is skipped if the length is too large